### PR TITLE
feat: accept 'dialog' as a method

### DIFF
--- a/lib/rules/require-form-method.js
+++ b/lib/rules/require-form-method.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const METHOD_VALUES = ["post", "get"];
+const METHOD_VALUES = ["post", "get", "dialog"];
 
 function withValidMethodAttribute(attributes) {
   const method = (attributes || []).find(


### PR DESCRIPTION
Catching up with the ever-improving standards, I propose adding 'dialog' as an accepted form method. See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#method